### PR TITLE
Add slog for log levels

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
+	"os"
 
 	"github.com/brk3/habits/internal/config"
 	"github.com/brk3/habits/internal/server"
@@ -19,6 +21,12 @@ var serverCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		consoleHandler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: cfg.SLogLevel,
+		})
+		logger := slog.New(consoleHandler)
+		slog.SetDefault(logger) // This also captures all the log.Println as INFO
 
 		log.Println("Opening DB...")
 		store, err := bolt.Open(cfg.DBPath)

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@
 #auth_token: "XXX"
 #db_path: habits.db
 #api_base_url: http://localhost:3000
+#log_level: info
 
 #server:
 #  host: 0.0.0.0


### PR DESCRIPTION
In my research, `slog` is the choice to use. It isn't an external dep, and thats all I need to really hear.

It can also do console writes simultaneously with writing to a log as a configuration step. Not sure I expect a log file to really be useful to this project, but it is easy to add and configure if you want.

Adds a new `log_level` config option that defaults to `INFO`