### PR TITLE
Fixes login for frontend

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,10 +122,10 @@ func (s *Server) Router() http.Handler {
 	if s.cfg.AuthEnabled {
 		r.Route("/auth", func(r chi.Router) {
 			r.Get("/login", s.simpleLogin)
-			r.Get("/{id}/login", s.login)
-			r.Get("/{id}/callback", s.callback)
-			r.Post("/{id}/logout", s.logout)
-			r.Get("/{id}/get_api_token", s.getAPIToken)
+			r.Get("/login/{id}", s.login)
+			r.Get("/callback/{id}", s.callback)
+			r.Get("/logout", s.logout)
+			r.Get("/get_api_token", s.getAPIToken)
 		})
 	}
 


### PR DESCRIPTION
Merge https://github.com/brk3/habits/pull/9 first https://github.com/brk3/habits/pull/10

The looping over cfg.authCfg will go away when we have a session id.

A major change in this patch is the url paths. These new paths are more
inline with how others do this.

/auth/login         -> simple login page with button redirects for each OIDC
/auth/login/{ID}    -> redirect to IDM for login
/auth/callback/{ID} -> IDM responds on this route
/auth/logout        -> wipe all cookies/sessions

You will need to update your `config.yaml` with the new redirect scheme,
and kanidm.

redirect_url: "https://habits.example.com/auth/callback/01K5JMC5SM2FQGQ6AYVJBBKMVJ"

$ kanidm system oauth2 add-redirect-url habits https://habits.example.com/auth/callback/01K5JMC5SM2FQGQ6AYVJBBKMVJ